### PR TITLE
Add fixes to support deployment on Ubuntu

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,9 @@ icecast_admin_user: icecast-admin
 icecast_admin_password: 
 icecast_hostname: example.com
 
+icecast_webroot: "{{ icecast_basedir }}/web"
+icecast_adminroot: "{{ icecast_basedir }}/admin"
+
 icecast_accesslog: access.log
 icecast_errorlog: error.log
 icecast_loglevel: 3

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-icecast_config_file: /etc/icecast.xml
 icecast_location: Earth
 icecast_admin_email: icemaster@localhost
 icecast_source_password: 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,8 +8,6 @@ icecast_relay_password:
 icecast_admin_user: icecast-admin
 icecast_admin_password: 
 icecast_hostname: example.com
-icecast_user: icecast
-icecast_group: icecast
 
 icecast_accesslog: access.log
 icecast_errorlog: error.log

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,5 +2,5 @@
 # Reload icecast after a config file update
 - name: reload icecast
   service:
-    name: icecast
+    name: "{{ icecast_service }}"
     state: restarted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,9 @@ galaxy_info:
       versions:
         - 6
         - 7
+    - name: Ubuntu
+      versions:
+        - focal
   galaxy_tags:
     - system
     - web

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,18 @@
 ---
+- name: Load OS-specific variables
+  include_vars: "{{lookup('first_found', params)}}"
+  vars:
+    params:
+      files:
+        - "{{ansible_distribution}}.yml"
+        - "{{ansible_os_family}}.yml"
+        - default.yml
+      paths:
+        - "vars"
+
 - name: Install Icecast
   package:
-    name: icecast
+    name: "{{ icecast_package }}"
     state: present
 
 - name: Install Icecast configuration file

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,9 +23,9 @@
     group: "{{ icecast_group }}"
     mode: 0640
   notify:
-    - reload icecast
+    - "reload {{ icecast_service }}"
 
 - name: Enable Icecast service
   service:
-    name: icecast
+    name: "{{ icecast_service }}"
     enabled: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
     group: "{{ icecast_group }}"
     mode: 0640
   notify:
-    - "reload {{ icecast_service }}"
+    - reload icecast
 
 - name: Enable Icecast service
   service:

--- a/templates/icecast.xml.j2
+++ b/templates/icecast.xml.j2
@@ -97,10 +97,10 @@
 
 {% endfor %}
   <paths>
-    <basedir>/usr/share/icecast</basedir>
-    <logdir>/var/log/icecast</logdir>
-    <webroot>/usr/share/icecast/web</webroot>
-    <adminroot>/usr/share/icecast/admin</adminroot>
+    <basedir>{{ icecast_basedir }}</basedir>
+    <logdir>{{ icecast_logdir }}</logdir>
+    <webroot>{{ icecast_webroot }}</webroot>
+    <adminroot>{{ icecast_adminroot }}</adminroot>
     <pidfile>/var/run/icecast.pid</pidfile>
     {% if icecast_ssl_certificate is defined %}
     <ssl-certificate>{{ icecast_ssl_certificate }}</ssl-certificate>

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,5 +1,8 @@
 ---
 icecast_config_file: /etc/icecast2/icecast.xml
+icecast_basedir: /usr/share/icecast2
+icecast_logdir: /var/log/icecast2
+
 icecast_package: icecast2
 icecast_user: icecast2
 icecast_group: icecast

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -2,3 +2,4 @@
 icecast_package: icecast2
 icecast_user: icecast2
 icecast_group: icecast
+icecast_service: icecast2

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,0 +1,2 @@
+---
+icecast_package: icecast2

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,2 +1,4 @@
 ---
 icecast_package: icecast2
+icecast_user: icecast2
+icecast_group: icecast2

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,4 +1,5 @@
 ---
+icecast_config_file: /etc/icecast2/icecast.xml
 icecast_package: icecast2
 icecast_user: icecast2
 icecast_group: icecast

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,4 +1,4 @@
 ---
 icecast_package: icecast2
 icecast_user: icecast2
-icecast_group: icecast2
+icecast_group: icecast

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -2,3 +2,4 @@
 icecast_package: icecast
 icecast_user: icecast
 icecast_group: icecast
+icecast_service: icecast

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,0 +1,4 @@
+---
+icecast_package: icecast
+icecast_user: icecast
+icecast_group: icecast

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,5 +1,8 @@
 ---
 icecast_config_file: /etc/icecast.xml
+icecast_basedir: /usr/share/icecast
+icecast_logdir: /var/log/icecast
+
 icecast_package: icecast
 icecast_user: icecast
 icecast_group: icecast

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,4 +1,5 @@
 ---
+icecast_config_file: /etc/icecast.xml
 icecast_package: icecast
 icecast_user: icecast
 icecast_group: icecast

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,3 +1,2 @@
 ---
 # vars file for ansible-icecast
-icecast_package: icecast

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,3 @@
 ---
 # vars file for ansible-icecast
+icecast_package: icecast


### PR DESCRIPTION
For some reason, the Ubuntu package is called `icecast2`, and there are some other details that are changed (service name, username, folders).

This introduces loading distribution specific variables, which are provided for Ubuntu. The defaults remain.

This was tested on Ubuntu 20.04 LTS (`focal`).